### PR TITLE
Respect explicit includes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,7 @@ inherit_gem:
 AllCops:
   Exclude:
     - vendor/**/*
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@ This plugin does just that. Any Markdown file in your site's source will be trea
 
 ## One potential gotcha
 
-In order to preserve backwards compatability, the plugin does not recognize [a short list of common meta files](https://github.com/benbalter/jekyll-optional-front-matter/blob/master/lib/jekyll-optional-front-matter.rb#L4). If you want Markdown files like your README, CONTRIBUTING file, CODE_OF_CONDUCT, or LICENSE, etc., you'll need to explicitly add YAML front matter to the file.
+In order to preserve backwards compatability, the plugin does not recognize [a short list of common meta files](https://github.com/benbalter/jekyll-optional-front-matter/blob/master/lib/jekyll-optional-front-matter.rb#L4).
+
+If you want Markdown files like your README, CONTRIBUTING file, CODE_OF_CONDUCT, or LICENSE, etc., you'll need to explicitly add YAML front matter to the file, or add it to your config's list of `include` files, e.g.:
+
+```yml
+include:
+  - CONTRIBUTING.md
+  - README.md
+```
 
 ## Disabling
 

--- a/jekyll-optional-front-matter.gemspec
+++ b/jekyll-optional-front-matter.gemspec
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
-$:.unshift File.expand_path('../lib', __FILE__)
-require 'jekyll-optional-front-matter/version'
+$LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
+require "jekyll-optional-front-matter/version"
 
 Gem::Specification.new do |s|
   s.name          = "jekyll-optional-front-matter"
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files app lib`.split("\n")
   s.platform      = Gem::Platform::RUBY
-  s.require_paths = ['lib']
+  s.require_paths = ["lib"]
   s.license       = "MIT"
 
   s.add_runtime_dependency "jekyll", "~> 3.0"

--- a/lib/jekyll-optional-front-matter/generator.rb
+++ b/lib/jekyll-optional-front-matter/generator.rb
@@ -48,11 +48,15 @@ module JekyllOptionalFrontMatter
 
     def whitelisted?(page)
       return false unless site.config["include"].is_a? Array
-      site.config["include"].include?(page.path)
+      entry_filter.included?(page.path)
     end
 
     def markdown_converter
       @markdown_converter ||= site.find_converter_instance(Jekyll::Converters::Markdown)
+    end
+
+    def entry_filter
+      @entry_filter ||= Jekyll::EntryFilter.new(site)
     end
   end
 end

--- a/lib/jekyll-optional-front-matter/generator.rb
+++ b/lib/jekyll-optional-front-matter/generator.rb
@@ -42,7 +42,13 @@ module JekyllOptionalFrontMatter
 
     # Does the given Jekyll::Page match our filename blacklist?
     def blacklisted?(page)
+      return false if whitelisted?(page)
       FILENAME_BLACKLIST.include?(page.basename.upcase)
+    end
+
+    def whitelisted?(page)
+      return false unless site.config["include"].is_a? Array
+      site.config["include"].include?(page.path)
     end
 
     def markdown_converter

--- a/spec/jekyll-optional-front-matter/generator_spec.rb
+++ b/spec/jekyll-optional-front-matter/generator_spec.rb
@@ -122,6 +122,7 @@ describe JekyllOptionalFrontMatter::Generator do
       it "matches #{filename}" do
         with_page(filename) do |page|
           expect(generator.send(:blacklisted?, page)).to eql(true)
+          expect(generator.send(:whitelisted?, page)).to eql(false)
         end
       end
     end

--- a/spec/jekyll-optional-front-matter/generator_spec.rb
+++ b/spec/jekyll-optional-front-matter/generator_spec.rb
@@ -105,6 +105,8 @@ describe JekyllOptionalFrontMatter::Generator do
   end
 
   context "blacklist" do
+    let(:site) { fixture_site("site", { "include" => ["foo.md"] }) }
+
     %w(
       README.md
       readme.markdown
@@ -128,6 +130,18 @@ describe JekyllOptionalFrontMatter::Generator do
       it "doesn't match #{filename}" do
         with_page(filename) do |page|
           expect(generator.send(:blacklisted?, page)).to eql(false)
+          expect(generator.send(:whitelisted?, page)).to eql(false)
+        end
+      end
+    end
+
+    context "whitelist" do
+      let(:site) { fixture_site("site", { "include" => ["CONTRIBUTING.md"] }) }
+
+      it "whitelists whitelisted files" do
+        with_page("CONTRIBUTING.md") do |page|
+          expect(generator.send(:blacklisted?, page)).to eql(false)
+          expect(generator.send(:whitelisted?, page)).to eql(true)
         end
       end
     end


### PR DESCRIPTION
A follow up to https://github.com/benbalter/jekyll-optional-front-matter/pull/2, this PR allows sites to explicitly include otherwise blacklisted "magic" files by adding them to the standard Jekyll `include` config key.