### PR TITLE
Add option to remove markdown files from output

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,23 @@ include:
   - README.md
 ```
 
-## Disabling
+## Configuration
+You can configure this plugin in `_config.yml` by adding to the `optional_front_matter` key.
+
+### Removing originals
+
+By default the original markdown files will be included as static pages in the output. To remove them from the output, add the `remove_originals` key:
+
+```yml
+optional_front_matter:
+  remove_originals: true
+```
+
+### Disabling
 
 Even if the plugin is enabled (e.g., via the `:jekyll_plugins` group in your Gemfile) you can disable it by adding the following to your site's config:
 
 ```yml
-require_front_matter: true
+optional_front_matter:
+  disabled: true
 ```

--- a/spec/jekyll-optional-front-matter/generator_spec.rb
+++ b/spec/jekyll-optional-front-matter/generator_spec.rb
@@ -187,7 +187,7 @@ describe JekyllOptionalFrontMatter::Generator do
         expect(names).to_not include("/index.md")
       end
 
-      it "does not remove blacklisted static files"
+      it "does not remove blacklisted static files" do
         expect(site.static_files.count).to eql(2)
         names = site.static_files.map(&:relative_path)
         expect(names).to include("/readme.md")


### PR DESCRIPTION
Implements #4 which can be activated via 

```yml
optional_front_matter:
  remove_originals: true
```

This plugin already had a configuration option `require_front_matter` placed in the root of the config file, but I didn't want to add another option to the root. Instead I've created a key with the same scheme used in `jekyll-titles-from-headings`, using the plugins name in snake_case without the leading `jekyll_`.

To be consolidate all options under this key, there's now also a `disabled` key that effectively does the same as `require_front_matter`. `require_front_matter` still works (and is part of the spec) to preserve backwards-compatibility, but is no longer mentioned in the documentation.
