### PR TITLE
Rename `disabled` to `enabled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This plugin does just that. Any Markdown file in your site's source will be trea
 
 ## One potential gotcha
 
-In order to preserve backwards compatability, the plugin does not recognize [a short list of common meta files](https://github.com/benbalter/jekyll-optional-front-matter/blob/master/lib/jekyll-optional-front-matter.rb#L4).
+In order to preserve backwards compatibility, the plugin does not recognize [a short list of common meta files](https://github.com/benbalter/jekyll-optional-front-matter/blob/master/lib/jekyll-optional-front-matter.rb#L4).
 
 If you want Markdown files like your README, CONTRIBUTING file, CODE_OF_CONDUCT, or LICENSE, etc., you'll need to explicitly add YAML front matter to the file, or add it to your config's list of `include` files, e.g.:
 

--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ Even if the plugin is enabled (e.g., via the `:jekyll_plugins` group in your Gem
 
 ```yml
 optional_front_matter:
-  disabled: true
+  enabled: false
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can configure this plugin in `_config.yml` by adding to the `optional_front_
 
 ### Removing originals
 
-By default the original markdown files will be included as static pages in the output. To remove them from the output, add the `remove_originals` key:
+By default the original markdown files will be included as static pages in the output. To remove them from the output, set the `remove_originals` key to `true`:
 
 ```yml
 optional_front_matter:

--- a/lib/jekyll-optional-front-matter/generator.rb
+++ b/lib/jekyll-optional-front-matter/generator.rb
@@ -78,7 +78,7 @@ module JekyllOptionalFrontMatter
     end
 
     def cleanup?
-      option(CLEANUP_KEY) || site.config["require_front_matter"]
+      option(CLEANUP_KEY) == true || site.config["require_front_matter"]
     end
   end
 end

--- a/lib/jekyll-optional-front-matter/generator.rb
+++ b/lib/jekyll-optional-front-matter/generator.rb
@@ -6,7 +6,7 @@ module JekyllOptionalFrontMatter
     priority :normal
 
     CONFIG_KEY = "optional_front_matter".freeze
-    DISABLED_KEY = "disabled".freeze
+    ENABLED_KEY = "enabled".freeze
     CLEANUP_KEY = "remove_originals".freeze
 
     def initialize(site)
@@ -74,7 +74,7 @@ module JekyllOptionalFrontMatter
     end
 
     def disabled?
-      option(DISABLED_KEY) || site.config["require_front_matter"]
+      option(ENABLED_KEY) == false || site.config["require_front_matter"]
     end
 
     def cleanup?

--- a/spec/jekyll-optional-front-matter/generator_spec.rb
+++ b/spec/jekyll-optional-front-matter/generator_spec.rb
@@ -93,7 +93,7 @@ describe JekyllOptionalFrontMatter::Generator do
 
   context "when disabled" do
     let(:site) do
-      fixture_site("site", { "optional_front_matter" => { "disabled" => true } })
+      fixture_site("site", { "optional_front_matter" => { "enabled" => false } })
     end
 
     context "generating" do
@@ -107,7 +107,7 @@ describe JekyllOptionalFrontMatter::Generator do
 
   context "when explicitly enabled" do
     let(:site) do
-      fixture_site("site", { "optional_front_matter" => { "disabled" => false } })
+      fixture_site("site", { "optional_front_matter" => { "enabled" => true } })
     end
 
     context "generating" do


### PR DESCRIPTION
To be consistent with benbalter/jekyll-titles-from-headings#25, benbalter/jekyll-relative-links#28 and benbalter/jekyll-readme-index#8,