### PR TITLE
Add option to convert markdown files in collections

### DIFF
--- a/spec/fixtures/site/_foo/no-front-matter.md
+++ b/spec/fixtures/site/_foo/no-front-matter.md
@@ -1,0 +1,1 @@
+# no front matter

--- a/spec/fixtures/site/_foo/raw.txt
+++ b/spec/fixtures/site/_foo/raw.txt
@@ -1,0 +1,1 @@
+this is a raw text file

--- a/spec/fixtures/site/_foo/yes-front-matter.md
+++ b/spec/fixtures/site/_foo/yes-front-matter.md
@@ -1,0 +1,3 @@
+---
+---
+# yes front matter

--- a/spec/jekyll-optional-front-matter/generator_spec.rb
+++ b/spec/jekyll-optional-front-matter/generator_spec.rb
@@ -219,4 +219,76 @@ describe JekyllOptionalFrontMatter::Generator do
       end
     end
   end
+
+  context "collections" do
+    context "when output false" do
+      let(:site) { fixture_site("site", { :collections => ["foo"] }) }
+      before { site.process }
+
+      it "does not output markdown files with front matter" do
+        expect(site.docs_to_write.count).to eql(2)
+        site.docs_to_write.map(&:url).each do |url|
+          expect(File.join(site.dest, url)).to be_an_existing_file
+        end
+        names = site.docs_to_write.map { |doc| File.basename(doc.url) }
+        expect(names).to include("no-front-matter.md")
+        expect(names).to include("raw.txt")
+      end
+    end
+
+    context "when output true" do
+      let(:site) { fixture_site("site", { :collections => { "foo" => { "output" => true } } }) }
+      before { site.process }
+
+      it "does convert markdown files with front matter into html" do
+        expect(site.docs_to_write.count).to eql(3)
+        site.docs_to_write.map(&:url).each do |url|
+          expect(File.join(site.dest, url)).to be_an_existing_file
+        end
+        names = site.docs_to_write.map { |doc| File.basename(doc.url) }
+        expect(names).to include("yes-front-matter.html")
+        expect(names).to include("no-front-matter.md")
+        expect(names).to include("raw.txt")
+      end
+    end
+
+    context "when collections true" do
+      let(:site) { fixture_site("site", {
+          :collections => { "foo" => { "output" => true } },
+          :optional_front_matter => { "collections" => true }
+      }) }
+      before { site.process }
+
+      it "also converts markdown files without front matter into html" do
+        expect(site.docs_to_write.count).to eql(4)
+        site.docs_to_write.map(&:url).each do |url|
+          expect(File.join(site.dest, url)).to be_an_existing_file
+        end
+        names = site.docs_to_write.map { |doc| File.basename(doc.url) }
+        expect(names).to include("yes-front-matter.html")
+        expect(names).to include("no-front-matter.md")
+        expect(names).to include("no-front-matter.html")
+        expect(names).to include("raw.txt")
+      end
+    end
+
+    context "when remove_originals false" do
+      let(:site) { fixture_site("site", {
+          :collections => { "foo" => { "output" => true } },
+          :optional_front_matter => { "collections" => true, "remove_originals" => true }
+      }) }
+      before { site.process }
+
+      it "also removes markdown files without front matter after converting into html" do
+        expect(site.docs_to_write.count).to eql(3)
+        site.docs_to_write.map(&:url).each do |url|
+          expect(File.join(site.dest, url)).to be_an_existing_file
+        end
+        names = site.docs_to_write.map { |doc| File.basename(doc.url) }
+        expect(names).to include("yes-front-matter.html")
+        expect(names).to include("no-front-matter.html")
+        expect(names).to include("raw.txt")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Implements [#5](https://github.com/benbalter/jekyll-optional-front-matter/issues/5) which can be enabled with the following configuration:

```yaml
optional_front_matter:
  collections: true
```

This option allows markdown files in collections to be converted to html without requiring front matter.

**Note:** It is important to set the collection's `output: true` to convert markdown files to html. Otherwise, html files will not be created.

```yaml
collections:
  foo:
    output: true
```

**Note:** By default, both markdown files and html files will be created. However, you can use `remove_originals: true` option to only create html files.

```yaml
optional_front_matter:
  remove_originals: true
  collections: true
```