### PR TITLE
Support Jekyll 4.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,5 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+
+require: rubocop-performance

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 rvm:
-  - 2.2
+  - 2.4
 before_install: gem install bundler
 language: ruby
 script: script/cibuild

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem 'rubocop-performance'
+
 gemspec

--- a/jekyll-optional-front-matter.gemspec
+++ b/jekyll-optional-front-matter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.license       = "MIT"
 
-  s.add_runtime_dependency "jekyll", "~> 3.0"
+  s.add_runtime_dependency "jekyll", ">= 3.0", "< 5.0"
   s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "rubocop", "~> 0.40"
 end

--- a/lib/jekyll-optional-front-matter/generator.rb
+++ b/lib/jekyll-optional-front-matter/generator.rb
@@ -7,9 +7,9 @@ module JekyllOptionalFrontMatter
     safe true
     priority :normal
 
-    CONFIG_KEY = "optional_front_matter".freeze
-    ENABLED_KEY = "enabled".freeze
-    CLEANUP_KEY = "remove_originals".freeze
+    CONFIG_KEY = "optional_front_matter"
+    ENABLED_KEY = "enabled"
+    CLEANUP_KEY = "remove_originals"
 
     def initialize(site)
       @site = site
@@ -18,6 +18,7 @@ module JekyllOptionalFrontMatter
     def generate(site)
       @site = site
       return if disabled?
+
       site.pages.concat(pages_to_add)
       site.static_files -= static_files_to_remove if cleanup?
     end
@@ -55,11 +56,13 @@ module JekyllOptionalFrontMatter
     # Does the given Jekyll::Page match our filename blacklist?
     def blacklisted?(page)
       return false if whitelisted?(page)
+
       FILENAME_BLACKLIST.include?(page.basename.upcase)
     end
 
     def whitelisted?(page)
       return false unless site.config["include"].is_a? Array
+
       entry_filter.included?(page.relative_path)
     end
 

--- a/lib/jekyll-optional-front-matter/version.rb
+++ b/lib/jekyll-optional-front-matter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JekyllOptionalFrontMatter
-  VERSION = "0.3.0".freeze
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
Need to upgrade to Jekyll 4.x because of https://jekyllrb.com/news/2018/09/19/security-fixes-for-3-6-3-7-3-8/

Also need your plugin :)