### PR TITLE
Added changes that were made in the now closed PR #18

### DIFF
--- a/lib/jekyll-optional-front-matter/generator.rb
+++ b/lib/jekyll-optional-front-matter/generator.rb
@@ -9,6 +9,7 @@ module JekyllOptionalFrontMatter
 
     CONFIG_KEY = "optional_front_matter"
     ENABLED_KEY = "enabled"
+    COLLECTIONS_KEY = "collections"
     CLEANUP_KEY = "remove_originals"
 
     def initialize(site)
@@ -21,6 +22,7 @@ module JekyllOptionalFrontMatter
 
       site.pages.concat(pages_to_add)
       site.static_files -= static_files_to_remove if cleanup?
+      collections_to_convert.each_value(&method(:convert_collection)) if collections?
     end
 
     private
@@ -53,6 +55,28 @@ module JekyllOptionalFrontMatter
       Jekyll::Page.new(site, base, dir, name)
     end
 
+    # Jekyll::Collections to convert Jekyll::StaticFiles to Jekyll::Documents
+    def collections_to_convert
+      site.collections.select { |k, _| !Jekyll::CollectionReader::SPECIAL_COLLECTIONS.include?(k) }
+    end
+
+    # Given a Jekyll::Collection, read Jekyll::StaticFile as Jekyll::Document
+    def convert_collection(collection)
+      file_names = collection.files.select { |file| markdown_converter.matches(file.extname) }.map(&:name)
+      full_paths = file_names.map { |e| collection.collection_dir(e) }
+      full_paths.each do |full_path|
+        next if File.directory?(full_path)
+        doc = Jekyll::Document.new(full_path, :site => site, :collection => collection)
+        doc.read
+        if site.unpublished || doc.published?
+          collection.docs << doc
+        end
+      end
+      collection.docs.sort!
+      collection.files.reject! { |file| markdown_converter.matches(file.extname) } if cleanup?
+    end
+
+
     # Does the given Jekyll::Page match our filename blacklist?
     def blacklisted?(page)
       return false if whitelisted?(page)
@@ -80,6 +104,10 @@ module JekyllOptionalFrontMatter
 
     def disabled?
       option(ENABLED_KEY) == false || site.config["require_front_matter"]
+    end
+
+    def collections?
+      option(COLLECTIONS_KEY) == true && !site.config["require_front_matter"]
     end
 
     def cleanup?

--- a/lib/jekyll-optional-front-matter/generator.rb
+++ b/lib/jekyll-optional-front-matter/generator.rb
@@ -57,25 +57,26 @@ module JekyllOptionalFrontMatter
 
     # Jekyll::Collections to convert Jekyll::StaticFiles to Jekyll::Documents
     def collections_to_convert
-      site.collections.select { |k, _| !Jekyll::CollectionReader::SPECIAL_COLLECTIONS.include?(k) }
+      site.collections.reject { |k, _| !Jekyll::CollectionReader::SPECIAL_COLLECTIONS.include?(k) }
     end
 
     # Given a Jekyll::Collection, read Jekyll::StaticFile as Jekyll::Document
     def convert_collection(collection)
-      file_names = collection.files.select { |file| markdown_converter.matches(file.extname) }.map(&:name)
+      file_names = collection.files.select {
+          |file| markdown_converter.matches(file.extname)
+         }.map(&:name)
       full_paths = file_names.map { |e| collection.collection_dir(e) }
       full_paths.each do |full_path|
         next if File.directory?(full_path)
+
         doc = Jekyll::Document.new(full_path, :site => site, :collection => collection)
         doc.read
-        if site.unpublished || doc.published?
-          collection.docs << doc
-        end
+
+        collection.docs << doc if site.unpublished || doc.published?
       end
       collection.docs.sort!
       collection.files.reject! { |file| markdown_converter.matches(file.extname) } if cleanup?
     end
-
 
     # Does the given Jekyll::Page match our filename blacklist?
     def blacklisted?(page)

--- a/spec/fixtures/site/_foo/no-front-matter.md
+++ b/spec/fixtures/site/_foo/no-front-matter.md
@@ -1,0 +1,3 @@
+# No front matter file
+
+This is a no front matter test file.

--- a/spec/fixtures/site/_foo/raw.txt
+++ b/spec/fixtures/site/_foo/raw.txt
@@ -1,0 +1,1 @@
+this is a raw text file

--- a/spec/fixtures/site/_foo/yes-front-matter.md
+++ b/spec/fixtures/site/_foo/yes-front-matter.md
@@ -1,0 +1,3 @@
+---
+---
+# yes front matter

--- a/spec/jekyll-optional-front-matter/generator_spec.rb
+++ b/spec/jekyll-optional-front-matter/generator_spec.rb
@@ -60,7 +60,7 @@ describe JekyllOptionalFrontMatter::Generator do
 
   context "collections" do
     context "when output false" do
-      let(:site) { fixture_site("site", { :collections => ["foo"] }) }
+      let(:site) { fixture_site("site", :collections => ["foo"]) }
       before { site.process }
 
       it "does not output markdown files with front matter" do
@@ -75,7 +75,7 @@ describe JekyllOptionalFrontMatter::Generator do
     end
 
     context "when output true" do
-      let(:site) { fixture_site("site", { :collections => { "foo" => { "output" => true } } }) }
+      let(:site) { fixture_site("site", :collections => { "foo" => { "output" => true } }) }
       before { site.process }
 
       it "does convert markdown files with front matter into html" do
@@ -91,10 +91,11 @@ describe JekyllOptionalFrontMatter::Generator do
     end
 
     context "when collections true" do
-      let(:site) { fixture_site("site", {
-          :collections => { "foo" => { "output" => true } },
-          :optional_front_matter => { "collections" => true }
-      }) }
+      let(:site)
+      fixture_site("site", {
+          :collections => {  "foo" => { "output" => true } },
+          :optional_front_matter => {  "collections" => true },
+      })
       before { site.process }
 
       it "also converts markdown files without front matter into html" do
@@ -111,10 +112,10 @@ describe JekyllOptionalFrontMatter::Generator do
     end
 
     context "when remove_originals false" do
-      let(:site) { fixture_site("site", {
+      let(:site) fixture_site("site", {
           :collections => { "foo" => { "output" => true } },
           :optional_front_matter => { "collections" => true, "remove_originals" => true }
-      }) }
+      })
       before { site.process }
 
       it "also removes markdown files without front matter after converting into html" do

--- a/spec/jekyll-optional-front-matter/generator_spec.rb
+++ b/spec/jekyll-optional-front-matter/generator_spec.rb
@@ -58,6 +58,78 @@ describe JekyllOptionalFrontMatter::Generator do
     expect(names).to include("another-file.markdown")
   end
 
+  context "collections" do
+    context "when output false" do
+      let(:site) { fixture_site("site", { :collections => ["foo"] }) }
+      before { site.process }
+
+      it "does not output markdown files with front matter" do
+        expect(site.docs_to_write.count).to eql(2)
+        site.docs_to_write.map(&:url).each do |url|
+          expect(File.join(site.dest, url)).to be_an_existing_file
+        end
+        names = site.docs_to_write.map { |doc| File.basename(doc.url) }
+        expect(names).to include("no-front-matter.md")
+        expect(names).to include("raw.txt")
+      end
+    end
+
+    context "when output true" do
+      let(:site) { fixture_site("site", { :collections => { "foo" => { "output" => true } } }) }
+      before { site.process }
+
+      it "does convert markdown files with front matter into html" do
+        expect(site.docs_to_write.count).to eql(3)
+        site.docs_to_write.map(&:url).each do |url|
+          expect(File.join(site.dest, url)).to be_an_existing_file
+        end
+        names = site.docs_to_write.map { |doc| File.basename(doc.url) }
+        expect(names).to include("yes-front-matter.html")
+        expect(names).to include("no-front-matter.md")
+        expect(names).to include("raw.txt")
+      end
+    end
+
+    context "when collections true" do
+      let(:site) { fixture_site("site", {
+          :collections => { "foo" => { "output" => true } },
+          :optional_front_matter => { "collections" => true }
+      }) }
+      before { site.process }
+
+      it "also converts markdown files without front matter into html" do
+        expect(site.docs_to_write.count).to eql(4)
+        site.docs_to_write.map(&:url).each do |url|
+          expect(File.join(site.dest, url)).to be_an_existing_file
+        end
+        names = site.docs_to_write.map { |doc| File.basename(doc.url) }
+        expect(names).to include("yes-front-matter.html")
+        expect(names).to include("no-front-matter.md")
+        expect(names).to include("no-front-matter.html")
+        expect(names).to include("raw.txt")
+      end
+    end
+
+    context "when remove_originals false" do
+      let(:site) { fixture_site("site", {
+          :collections => { "foo" => { "output" => true } },
+          :optional_front_matter => { "collections" => true, "remove_originals" => true }
+      }) }
+      before { site.process }
+
+      it "also removes markdown files without front matter after converting into html" do
+        expect(site.docs_to_write.count).to eql(3)
+        site.docs_to_write.map(&:url).each do |url|
+          expect(File.join(site.dest, url)).to be_an_existing_file
+        end
+        names = site.docs_to_write.map { |doc| File.basename(doc.url) }
+        expect(names).to include("yes-front-matter.html")
+        expect(names).to include("no-front-matter.html")
+        expect(names).to include("raw.txt")
+      end
+    end
+  end
+
   context "generating" do
     before { generator.generate(site) }
 


### PR DESCRIPTION
Original author: @kimbaudi

Implements #5 which can be enabled with the following configuration:

```yaml
optional_front_matter:
  collections: true
```

This option allows markdown files in collections to be converted to html without requiring front matter.

**Note:** It is important to set the collection's `output: true` to convert markdown files to html. Otherwise, html files will not be created.

```yaml
collections:
  foo:
    output: true
```
Note: By default, both markdown files and html files will be created. However, you can use `remove_originals: true` option to only create html files.

```yaml
optional_front_matter:
  remove_originals: true
  collections: true
```
*********
Thanks @benbalter for looking at this in advance!

Cheers!

Kyle

-----
[View rendered spec/fixtures/site/_foo/no-front-matter.md](https://github.com/kylekirkby/jekyll-optional-front-matter/blob/feature/adding_collection_support/spec/fixtures/site/_foo/no-front-matter.md)
[View rendered spec/fixtures/site/_foo/yes-front-matter.md](https://github.com/kylekirkby/jekyll-optional-front-matter/blob/feature/adding_collection_support/spec/fixtures/site/_foo/yes-front-matter.md)