### PR TITLE
docs: Update usage instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,28 +15,29 @@ This plugin does just that. Any Markdown file in your site's source will be trea
 ## Usage
 
 1. Add the following to your site's Gemfile:
-
     ```ruby
-    gem 'jekyll-optional-front-matter'
+    group :jekyll_plugins do
+      gem 'jekyll-optional-front-matter'
+    end
     ```
-
-2. Install with Gem or Bundler
-
-    ```bash
-    $ gem install jekyll-optional-front-matter # May need sudo
-    ```
-    If the above does not work try:
-
-      ```bash
-      $ bundler install jekyll-optional-front-matter # May need sudo
-      ```
-
+2. Install the plugin.
+    - Using Bundler.
+        ```bash
+        $ bundler install
+        ```
+    - Using Gem.
+        ```bash
+        $ # Install in your user's home directory.
+        $ gem install jekyll-optional-front-matter --user-install
+        $ # Install for root user.
+        $ sudo gem install jekyll-optional-front-matter
+        ```
 3. Add the following to your site's config file:
-
     ```yml
     plugins:
-    - jekyll-optional-front-matter
+      - jekyll-optional-front-matter
     ```
+
 Note: If you are using a Jekyll version less than 3.5.0, use the `gems` key instead of `plugins`.
 
 ## One potential gotcha


### PR DESCRIPTION
I made a change to the bundle step.

`bundle install GEM` is not valid as it does not take a Gemfile name.

```
bundle install jekyll-optional-front-matter
ERROR: "bundle install" was called with arguments ["jekyll-optional-front-matter"]
Usage: "bundle install [OPTIONS]"
```

You need just to say `bundle install` as in my doc change and it will read from the Gemfile.

Or you can use use `add` as `bundle add GEM`. But, the `add` commands appends a line to the Gemfile which is already covered in step 1. Also I don't find `add` useful at all. So I went with `install`.

I also cleaned up other steps so that I think make more sense now. I hope those changes are okay.

Thanks

-----
[View rendered README.md](https://github.com/MichaelCurrin/jekyll-optional-front-matter/blob/docs-update-usage-steps/README.md)