### PR TITLE
Maintain sort order of pages after adding files without front matter

### DIFF
--- a/lib/jekyll-optional-front-matter/generator.rb
+++ b/lib/jekyll-optional-front-matter/generator.rb
@@ -19,14 +19,8 @@ module JekyllOptionalFrontMatter
       @site = site
       return if disabled?
 
-      # Add pages to the site
-      pages_to_add.each do |page|
-        # Pre-convert the content of pages without front matter to ensure
-        # page.content contains HTML instead of Markdown
-        convert_content(page)
-        site.pages << page
-      end
-
+      site.pages.concat(pages_to_add)
+      site.pages.sort_by!(&:name)
       site.static_files -= static_files_to_remove if cleanup?
     end
 

--- a/spec/jekyll-optional-front-matter/content_spec.rb
+++ b/spec/jekyll-optional-front-matter/content_spec.rb
@@ -31,14 +31,13 @@ describe JekyllOptionalFrontMatter::Generator do
       generator.generate(site)
     end
 
-    it "converts markdown content to HTML for pages without front matter" do
-      # Get a page that has been added by the plugin (without front matter)
-      page = site.pages.find { |p| p.name == "file.md" }
-      puts "After generator - Page without FM content: #{page.content.inspect}"
+    it "keeps pages sorted after adding file.md without front matter" do
+      filenames = site.pages.map(&:name)
+      file_index = filenames.index("file.md")
+      index_index = filenames.index("index.md")
 
-      # The content should be HTML after the generator runs
-      expect(page.content).not_to eq("# File\n")
-      expect(page.content).to include("<h1")
+      # Verify the order of pages
+      expect(file_index).to be < index_index
     end
 
     it "does not affect pages with front matter" do


### PR DESCRIPTION
Another attempt at closing #42: this simply sorts the `pages` array again by the pages' `name` property after adding pages without front matter, so these are effectively inserted in the correct place in the sort order (assuming the pages were already sorted before by Jekyll). This would replace the Copilot fix of rendering the pages early.

Also changed one of the tests to verify the correct insertion of the new page (replacing the test that checks that the generator already renders the pages).