### PR TITLE
Bump rubocop-rspec to ~> 3.0

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,9 +32,9 @@ RSpec/ExampleLength:
   Max: 7
 
 # Offense count: 2
-# Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
+# Configuration parameters: Include, CustomTransform, IgnoreMethods.
 # Include: **/*_spec*rb*, **/spec/**/*
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
   Exclude:
     - 'spec/jekyll-optional-front-matter/content_spec.rb'
     - 'spec/jekyll-optional-front-matter/generator_spec.rb'

--- a/jekyll-optional-front-matter.gemspec
+++ b/jekyll-optional-front-matter.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rubocop", "~> 1.18"
   s.add_development_dependency "rubocop-jekyll", "~> 0.10"
   s.add_development_dependency "rubocop-performance", "~> 1.5"
-  s.add_development_dependency "rubocop-rspec", "2.21.0"
+  s.add_development_dependency "rubocop-rspec", "~> 3.0"
 end


### PR DESCRIPTION
## What

Moves the `rubocop-rspec` dev dependency off its exact `2.21.0` pin to `~> 3.0`.

## Why

Dependabot leaves exact version pins alone, so this was the one core plugin whose `rubocop-rspec` had silently gone stale while the others moved to 3.x — hence no open Dependabot PR to bump it.

## Compatibility change

rubocop-rspec 3.0 split the `RSpec/FilePath` cop into `RSpec/SpecFilePathFormat` and `RSpec/SpecFilePathSuffix`. The existing `.rubocop_todo.yml` exclusion was a path-format offense, so it's remapped to `RSpec/SpecFilePathFormat`.

## Verification

`bundle exec rubocop` runs **clean** on the codebase under rubocop-rspec 3.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)