### PR TITLE
Release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
-## Unreleased
+## 0.3.3
 
-* Fixed issue where `page.content` contained Markdown text rather than HTML for pages without front matter when applying a template. This was caused by pages without front matter being rendered after all other pages.
+* Fixed issue where `page.content` contained Markdown text rather than HTML for pages without front matter when applying a template. This was caused by pages without front matter being rendered after all other pages. (#43)
+* Maintain the sort order of pages after adding files without front matter (#44)
+* Modernize CI (test Ruby 3.3 & 4.0 against Jekyll 3.x & 4.x) and bump rubocop-rspec to `~> 3.0` (#47, #48)
+* Enable Dependabot for GitHub Actions; add a CodeQL analysis workflow

--- a/lib/jekyll-optional-front-matter/version.rb
+++ b/lib/jekyll-optional-front-matter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JekyllOptionalFrontMatter
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end


### PR DESCRIPTION
Prepares **v0.3.3** (patch). Converts the existing `CHANGELOG.md` "Unreleased" section to 0.3.3. Publish is a manual `gem push` after merge.

**Bump:** 0.3.2 → 0.3.3

### Changelog
- Fixed `page.content` containing Markdown rather than HTML for pages without front matter when applying a template (#43)
- Maintain the sort order of pages after adding files without front matter (#44)
- Modernize CI (Ruby 3.3 & 4.0 × Jekyll 3.x & 4.x); bump rubocop-rspec to `~> 3.0` (#47, #48)
- Enable Dependabot for GitHub Actions; add CodeQL workflow

_Patch: bug fixes + maintenance._

🤖 Generated with [Claude Code](https://claude.com/claude-code)