### PR TITLE
Declare required_ruby_version >= 3.0

### DIFF
--- a/jekyll-optional-front-matter.gemspec
+++ b/jekyll-optional-front-matter.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.platform      = Gem::Platform::RUBY
   s.require_paths = ["lib"]
   s.license       = "MIT"
-  s.required_ruby_version = ">= 2.5"
+  s.required_ruby_version = ">= 3.0"
 
   s.add_runtime_dependency "jekyll", ">= 3.0", "< 5.0"
   s.add_development_dependency "kramdown-parser-gfm", "~> 1.0"


### PR DESCRIPTION
Sets `s.required_ruby_version = ">= 3.0"` to match the supported/tested Ruby matrix (3.3, 4.0) and clear the `gem build` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)